### PR TITLE
#162725221 Implement social login for google and facebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ coverage
 yarn-error.log
 .DS_Store
 .env
-comments

--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/__mocks__/styleMocks.js
+++ b/__mocks__/styleMocks.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": " jest --collectCoverage",
-    "start": "webpack-dev-server --open --mode development --hot",
+    "start": "webpack-dev-server --open --mode development --hot --https",
     "build": "webpack --mode production --open --hot",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -21,16 +21,21 @@
     "@babel/cli": "^7.2.3",
     "argon-design-system-free": "^1.0.1",
     "dotenv": "^6.2.0",
+    "babel-polyfill": "^6.26.0",
     "dotenv-webpack": "^1.7.0",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.9.1",
     "enzyme-to-json": "^3.3.5",
     "file-loader": "^3.0.1",
     "image-webpack-loader": "^4.6.0",
+    "prop-types": "^15.7.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
+    "react-facebook-login": "^4.1.1",
+    "react-google-login": "^5.0.2",
     "react-redux": "^6.0.0",
     "react-router-dom": "^4.3.1",
+    "react-toastify": "^4.5.2",
     "redux": "^4.0.1",
     "redux-devtools-extension": "^2.13.8",
     "redux-thunk": "^2.3.0",
@@ -60,7 +65,9 @@
     "fetch-mock": "^7.3.0",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.2.0",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^24.1.0",
+    "jest-localstorage-mock": "^2.4.0",
     "node-fetch": "^2.3.0",
     "node-sass": "^4.11.0",
     "redux-mock-store": "^1.5.3",
@@ -83,5 +90,11 @@
   "bugs": {
     "url": "https://github.com/andela/Ah-frontend-xmen/issues"
   },
-  "homepage": "https://github.com/andela/Ah-frontend-xmen#readme"
+  "homepage": "https://github.com/andela/Ah-frontend-xmen#readme",
+  "jest": {
+    "moduleNameMapper": {
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(css|less)$": "identity-obj-proxy"
+    }
+  }
 }

--- a/src/actions/ActionTypes.js
+++ b/src/actions/ActionTypes.js
@@ -4,3 +4,10 @@ const ActionTypes = {
 };
 
 export default ActionTypes;
+export const FACEBOOK_SIGNIN_SUCCESS = 'FACEBOOK_SIGNIN_SUCCESS';
+
+export const FACEBOOK_SIGNIN_FAIL = 'FACEBOOK_SIGNIN_FAIL';
+
+export const GOOGLE_SIGNIN_SUCCESS = 'GOOGLE_SIGNIN_SUCCESS';
+
+export const GOOGLE_SIGNIN_FAIL = 'GOOGLE_SIGNIN_FAIL';

--- a/src/actions/socialActions/__tests__/socialActions.test.js
+++ b/src/actions/socialActions/__tests__/socialActions.test.js
@@ -1,0 +1,30 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import fetchMock from 'fetch-mock';
+import { BASE_URL } from '../../../constants';
+import googleSignIn from '../googleAction';
+import facebookLoginAction from '../facebookAction';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+
+describe('async actions', () => {
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it('dispatch actions for google login', () => {
+    fetchMock.post(`${BASE_URL}/users/google-login/`, { auth_token: 'token' });
+    const store = mockStore({});
+    store.dispatch(googleSignIn({ auth_token: 'token' }));
+    expect(store.getActions()).toEqual([]);
+  });
+
+  it('dispatch actions for facebook login', () => {
+    fetchMock.post(`${BASE_URL}/users/facebook-login/`, { auth_token: 'token' });
+    const store = mockStore({});
+    store.dispatch(facebookLoginAction({ auth_token: 'token' }));
+    expect(store.getActions()).toEqual([]);
+  });
+});

--- a/src/actions/socialActions/facebookAction.js
+++ b/src/actions/socialActions/facebookAction.js
@@ -1,0 +1,30 @@
+import { FACEBOOK_SIGNIN_SUCCESS, FACEBOOK_SIGNIN_FAIL } from '../ActionTypes';
+import { BASE_URL } from '../../constants';
+
+const facebookSignIn = auth_token => (dispatch) => {
+  fetch(`${BASE_URL}/users/facebook-login/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ auth_token }),
+  }).then(
+    res => res.json(),
+  ).then(
+    (data) => {
+      if (data.errors) {
+        dispatch({
+          type: FACEBOOK_SIGNIN_FAIL,
+          payload: data.errors,
+        });
+      } else {
+        dispatch({
+          type: FACEBOOK_SIGNIN_SUCCESS,
+          payload: data,
+        });
+      }
+    },
+  );
+};
+
+export default facebookSignIn;

--- a/src/actions/socialActions/googleAction.js
+++ b/src/actions/socialActions/googleAction.js
@@ -1,0 +1,37 @@
+import { GOOGLE_SIGNIN_SUCCESS, GOOGLE_SIGNIN_FAIL } from '../ActionTypes';
+import { BASE_URL } from '../../constants';
+
+
+const googleSignIn = auth_token => (dispatch) => {
+  fetch(`${BASE_URL}/users/google-login/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ auth_token }),
+  }).then(
+    res => res.json(),
+  ).then(
+    (data) => {
+      if (data.errors) {
+        dispatch({
+          type: GOOGLE_SIGNIN_FAIL,
+          payload: data.errors,
+        });
+      } else {
+        dispatch({
+          type: GOOGLE_SIGNIN_SUCCESS,
+          payload: data,
+          token: data.user.token,
+        });
+      }
+    },
+  ).catch((err) => {
+    dispatch({
+      type: GOOGLE_SIGNIN_FAIL,
+      payload: err,
+    });
+  });
+};
+
+export default googleSignIn;

--- a/src/assets/css/socialAuth.css
+++ b/src/assets/css/socialAuth.css
@@ -1,0 +1,14 @@
+.google-btn{
+    background:#f5365c !important;
+    color: white !important;
+    display: inline-block !important;
+    border-radius: 60px !important; 
+    padding: 1.3em 0.6em !important;
+}
+
+.facebook-btn{
+    color: white !important;
+    display: inline-block !important;
+    border-radius: 60px !important; 
+    padding: 1.3em 1.8em !important;   
+}

--- a/src/components/socialAuth/__snapshots__/socialAuth.test.js.snap
+++ b/src/components/socialAuth/__snapshots__/socialAuth.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SocialAuth should render without crushing 1`] = `ShallowWrapper {}`;

--- a/src/components/socialAuth/socialAuth.js
+++ b/src/components/socialAuth/socialAuth.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import GoogleLogin from 'react-google-login';
+import FacebookLogin from 'react-facebook-login';
+import PropTypes from 'prop-types';
+
+
+const socialAuthButtons = props => (
+  <div id="social-button">
+    <p className="text-dark">Login with Social</p>
+
+    <FacebookLogin
+      appId={process.env.appId}
+      fields="name,email,picture"
+      callback={props.responseFacebook}
+      cssClass="btn btn-primary mr-2 facebook-btn"
+      textButton={<i className="fab fa-2x fa-facebook-f" />}
+      icon={false}
+    />
+
+    <GoogleLogin
+      clientId={process.env.clientId}
+      onSuccess={props.googleResponseSuccess}
+      onFailure={props.googleResponseFailure}
+      icon={false}
+      className="google-btn btn btn-primary"
+      buttonText={<i className="fab fa-2x fa-google" />}
+    />
+
+
+  </div>
+);
+
+socialAuthButtons.prototype = {
+  responseFacebook: PropTypes.func.isRequired,
+  googleResponseSuccess: PropTypes.func.isRequired,
+  googleResponseFailure: PropTypes.func.isRequired,
+};
+export default socialAuthButtons;

--- a/src/components/socialAuth/socialAuth.test.js
+++ b/src/components/socialAuth/socialAuth.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import SocialAuth from './socialAuth';
+
+
+describe('<SocialAuth', () => {
+  it('should render without crushing', () => {
+    const wrapper = shallow(<SocialAuth />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,1 @@
+export const BASE_URL = process.env.BASE_URL;

--- a/src/index.html
+++ b/src/index.html
@@ -5,8 +5,12 @@
   <link href="https://fonts.googleapis.com/css?family=Patua+One" rel="stylesheet">
   <link href="./node_modules/argon-design-system-free/assets/vendor/nucleo/css/nucleo.css" rel="stylesheet">
   <title>Authors Haven</title>
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
+  
 </head>
 <body>
   <div id="root"></div>
+  
+
 </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ import store from './Store';
 import './assets/style.scss';
 import './assets/css/style.css';
 import '../node_modules/argon-design-system-free/assets/css/argon.css';
+import './assets/css/socialAuth.css';
+import 'react-toastify/dist/ReactToastify.css';
 
 
 ReactDOM.render(

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,6 +1,9 @@
 import { combineReducers } from 'redux';
 import fetchArticlesReducer from './fetchArticlesReducer';
+import socialAuthReducer from './socialAuthReducer/socialAuthReducer';
 
 export default combineReducers({
   articles: fetchArticlesReducer,
+  socialAuthReducer,
+
 });

--- a/src/reducers/socialAuthReducer/__tests__/socialAuthReducer.test.js
+++ b/src/reducers/socialAuthReducer/__tests__/socialAuthReducer.test.js
@@ -1,0 +1,62 @@
+import socialAuthReducer from '../socialAuthReducer';
+import {
+  GOOGLE_SIGNIN_SUCCESS, GOOGLE_SIGNIN_FAIL,
+  FACEBOOK_SIGNIN_SUCCESS,
+  FACEBOOK_SIGNIN_FAIL,
+} from '../../../actions/ActionTypes';
+
+
+describe('Social Auth Reducer', () => {
+  it('should return the initial state', () => {
+    expect(socialAuthReducer(undefined, {})).toEqual(
+      {
+        isAuthenticated: false,
+        facebook_login: false,
+        google_login: false,
+        payload: '',
+        token: '',
+      },
+    );
+  });
+
+  it('should update state if GOOGLE LOGIN SUCCESS', () => {
+    expect(socialAuthReducer([], { type: GOOGLE_SIGNIN_SUCCESS, payload: '' })).toEqual({
+      google_login: true,
+      isAuthenticated: true,
+      payload: '',
+      token: undefined,
+    });
+  });
+
+  it('should update state if GOOGLE LOGIN FAILS', () => {
+    expect(socialAuthReducer([], { type: GOOGLE_SIGNIN_FAIL, payload: '' })).toEqual({
+      payload: '',
+    });
+  });
+
+  it('should update state if FACEBOOKLOGIN SUCCESS', () => {
+    expect(socialAuthReducer([], {
+      type: FACEBOOK_SIGNIN_SUCCESS,
+      payload: {
+        user: {
+          token: 'atoken',
+        },
+      },
+    })).toEqual({
+      facebook_login: true,
+      isAuthenticated: true,
+      payload: {
+        user: {
+          token: 'atoken',
+        },
+      },
+      token: 'atoken',
+    });
+  });
+
+  it('should update state if FACEBOOKLOGIN FAILs', () => {
+    expect(socialAuthReducer([], { type: FACEBOOK_SIGNIN_FAIL, payload: '' })).toEqual({
+      payload: '',
+    });
+  });
+});

--- a/src/reducers/socialAuthReducer/socialAuthReducer.js
+++ b/src/reducers/socialAuthReducer/socialAuthReducer.js
@@ -1,0 +1,50 @@
+import {
+  FACEBOOK_SIGNIN_FAIL,
+  FACEBOOK_SIGNIN_SUCCESS,
+  GOOGLE_SIGNIN_SUCCESS,
+  GOOGLE_SIGNIN_FAIL,
+} from '../../actions/ActionTypes';
+
+const initialState = {
+  isAuthenticated: false,
+  facebook_login: false,
+  google_login: false,
+  payload: '',
+  token: '',
+};
+
+const socialAuthReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case GOOGLE_SIGNIN_SUCCESS:
+      return {
+        ...state,
+        isAuthenticated: true,
+        google_login: true,
+        token: action.token,
+        payload: action.payload,
+
+      };
+    case GOOGLE_SIGNIN_FAIL:
+      return {
+        ...state,
+        payload: action.payload,
+      };
+    case FACEBOOK_SIGNIN_SUCCESS:
+      return {
+        ...state,
+        isAuthenticated: true,
+        facebook_login: true,
+        token: action.payload.user.token,
+        payload: action.payload,
+      };
+    case FACEBOOK_SIGNIN_FAIL:
+      return {
+        ...state,
+        payload: action.payload,
+      };
+    default:
+      return state;
+  }
+};
+
+export default socialAuthReducer;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
-
+import LoginView from '../views/LoginView';
 import HomeView from '../views/HomeView';
 import Header from '../components/Shared/Header';
 import Footer from '../components/Shared/Footer';
@@ -10,6 +10,7 @@ const Routes = () => (
     <div>
       <Header />
       <Route path="/" exact strict component={HomeView} />
+      <Route path="/login" exact strict component={LoginView} />
       <Footer />
     </div>
   </Router>

--- a/src/views/LoginView.js
+++ b/src/views/LoginView.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import Login from '../components/Login';
+import SocialAuthView from './socialAuthView/socialAuthView';
+
+const LoginView = props => (
+  <div>
+    <SocialAuthView />
+    <Login />
+
+  </div>
+);
+
+export default LoginView;

--- a/src/views/socialAuthView/__snapshots__/socialAuthView.test.js.snap
+++ b/src/views/socialAuthView/__snapshots__/socialAuthView.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SocialAuthView /> should render without crashing 1`] = `ShallowWrapper {}`;

--- a/src/views/socialAuthView/socialAuthView.js
+++ b/src/views/socialAuthView/socialAuthView.js
@@ -1,0 +1,67 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { ToastContainer, toast } from 'react-toastify';
+import SocialAuth from '../../components/socialAuth/socialAuth';
+import googleSignInAction from '../../actions/socialActions/googleAction';
+import facebookSignInAction from '../../actions/socialActions/facebookAction';
+
+
+export class SocialAuthView extends Component {
+  componentWillReceiveProps(nextprops) {
+    if (nextprops.socialAuthState.isAuthenticated) {
+      localStorage.setItem('token', nextprops.socialAuthState.token);
+      localStorage.setItem('username', nextprops.socialAuthState.payload.user.username);
+      setTimeout(() => {
+        this.props.history.push('/');
+      }, 800);
+      toast.success(`Successully Logged in as ${nextprops.socialAuthState.payload.user.username}`);
+    } else {
+      toast.error('!Oops An Error occurred Please Try Again Later');
+    }
+  }
+
+    handleFacebookReponse=(response) => {
+      const { facebookSignInAction } = this.props;
+      if (response.accessToken) {
+        facebookSignInAction(response.accessToken);
+      }
+    }
+
+    handleGoogleResponseSuccess=(response) => {
+      
+      const { googleSignInAction } = this.props;
+      if (response.tokenId) {
+        googleSignInAction(response.tokenId);
+      }
+    }
+
+    handlegoogleResponseFailure=(response) => {
+      toast.error(response.error);
+      const { googleSignInAction } = this.props;
+      googleSignInAction('invalid request');
+    }
+
+
+    render() {
+      return (
+        <div>
+          <ToastContainer />
+          <SocialAuth
+            id="socialAuth"
+            responseFacebook={this.handleFacebookReponse}
+            googleResponseSuccess={this.handleGoogleResponseSuccess}
+            googleResponseFailure={this.handlegoogleResponseFailure}
+          />
+        </div>
+
+      );
+    }
+}
+
+export const mapStateToProps = state => ({
+  socialAuthState: state.socialAuthReducer,
+});
+
+export default withRouter(connect(mapStateToProps,
+  { googleSignInAction, facebookSignInAction })(SocialAuthView));

--- a/src/views/socialAuthView/socialAuthView.test.js
+++ b/src/views/socialAuthView/socialAuthView.test.js
@@ -1,0 +1,116 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { SocialAuthView, mapStateToProps } from './socialAuthView';
+
+const push = jest.fn();
+const props = {
+  googleSignInAction: jest.fn(),
+  facebookSignInAction: jest.fn(),
+  payload: {
+    user: {
+      token: 'usertoken',
+    },
+    errors: {
+      errors: "['The auth_token is expired or invalid']",
+    },
+  },
+  socialAuthState: {
+    isAuthenticated: false,
+    facebook_login: false,
+    google_login: false,
+    payload: '',
+    token: '',
+  },
+  history: { push },
+};
+
+const initialState = {
+  isAuthenticated: false,
+  facebook_login: false,
+  google_login: false,
+  payload: '',
+  token: '',
+};
+
+let wrapper;
+
+describe('<SocialAuthView />', () => {
+  beforeEach(() => {
+    wrapper = shallow(<SocialAuthView {...props} />);
+  });
+
+  it('should render without crashing', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should call handle google signIn action', () => {
+    wrapper.instance().handlegoogleResponseFailure({
+      auth_token: 'token',
+    });
+    expect(wrapper.instance().props.googleSignInAction).toBeCalled();
+  });
+
+  it('should update next props', () => {
+    wrapper.setProps({
+      socialAuthState: {
+        isAuthenticated: true,
+        payload: {
+          user: {
+            username: 'dee',
+          },
+        },
+      },
+    });
+
+    expect(wrapper.instance().props.socialAuthState).toEqual({
+      isAuthenticated: true,
+      payload: {
+        user: {
+          username: 'dee',
+        },
+      },
+    });
+  });
+
+  it('should call handle google sign in success', () => {
+    wrapper.setProps({
+      response: {
+        tokenId: 'a fake google token',
+      },
+    });
+
+    wrapper.instance().handleGoogleResponseSuccess(wrapper.instance().props.response);
+    expect(wrapper.instance().props.response).toEqual({ tokenId: 'a fake google token' });
+  });
+  it('should handle google sign in fail', () => {
+    wrapper.setProps({
+      response: {
+        error: 'a fake google error',
+      },
+    });
+    wrapper.instance().handlegoogleResponseFailure(wrapper.instance().props.response.error);
+    expect(wrapper.instance().props.googleSignInAction).toBeCalled();
+  });
+
+  it('should call facebook sign in action', () => {
+    wrapper.setProps({
+      response: {
+        accessToken: 'a fake google token',
+      },
+    });
+
+    wrapper.instance().handleFacebookReponse(wrapper.instance().props.response);
+    expect(wrapper.instance().props.facebookSignInAction).toBeCalled();
+  });
+
+  it('should return state from redux store', () => {
+    expect(mapStateToProps(initialState).props).toEqual(undefined);
+  });
+  it('should store token in local storage', () => {
+    wrapper.setProps({
+      response: {
+        tokenId: 'a fake google token',
+      },
+    });
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const Dotenv = require('dotenv-webpack');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
+
 module.exports = {
   entry: ['./src/index.js'],
   output: {
@@ -59,8 +60,10 @@ module.exports = {
       template: './src/index.html',
       filename: './index.html',
     }),
+    new Dotenv(),
   ],
   devServer: {
     historyApiFallback: true,
   },
+
 };


### PR DESCRIPTION
#### What does this PR do?
Enables social login for google and facebook

#### Description of Task to be completed?
- create a presentational component for social login buttons
- create a container component to handle state for social authentication
- connect to facebook and twitter apps for Xmen
- set up actions, action Types and reducers for social authentication
- connect to facebook and google to get access tokens and post to the  backend
- register users successfully and store tokens in local storage

#### How should this be manually tested?
- Fetch and checkout into this branch with `git fetch origin ft-social-authentication-162725221 && git checkout ft-social-authentication-162725221`
- Install dependencies and start the app with `yarn install && yarn start`
- navigate to `https://localhost:8080/login` and click on one of the icons you which to use for login
- you will be redirected to a login page for one the platforms
- login with your credentials and if it's successful you will be redirected to the home page
- you might be faced with a problem of `https` because facebook login can only be accessed via an `https` connection just add exceptions for all your browsers
- To run tests run the command `yarn run test:coverage`

#### What are the relevant pivotal tracker stories?
[#162725221](https://www.pivotaltracker.com/story/show/162725221)



[Starts #162725221]

**Screenshots**
![screen shot 2019-02-17 at 6 01 24 pm](https://user-images.githubusercontent.com/39124174/52914933-08e79000-32df-11e9-9d34-9232ea706895.png)
![screen shot 2019-02-17 at 6 08 57 pm](https://user-images.githubusercontent.com/39124174/52914954-2caad600-32df-11e9-9820-d3e0c713bf13.png)
