### PR TITLE
164241177 Users should visit profiles

### DIFF
--- a/src/actions/ProfileActions.js
+++ b/src/actions/ProfileActions.js
@@ -2,7 +2,6 @@ import * as actions from './ActionTypes';
 import { BASE_URL } from '../constants';
 
 
-const username = localStorage.getItem('username');
 const token = localStorage.getItem('token');
 
 export function handleErrors(response) {
@@ -12,7 +11,10 @@ export function handleErrors(response) {
   return response;
 }
 
-export default function fetchProfile() {
+export default function fetchProfile(username) {
+  if (username === undefined) {
+    username = localStorage.getItem('username');
+  }
   return (dispatch) => {
     dispatch(actions.getProfileBegin());
     return fetch(`${BASE_URL}/profiles/${username}`,

--- a/src/components/Articles/ArticleComponent.js
+++ b/src/components/Articles/ArticleComponent.js
@@ -19,7 +19,7 @@ function parseName(author) {
 }
 
 function parseAvatar(image) {
-  if (image === null) return '/src/assets/images/avatar.png';
+  if (image === null) return 'https://res.cloudinary.com/soultech/image/upload/v1550685426/authors%20haven%20pics/avatar.png';
   return image;
 }
 
@@ -35,7 +35,7 @@ const ArticleComponent = props => (
       <div className="">
         <h1 className="display-2">{props.title}</h1>
       </div>
-      <Link to={`/profile/${props.author.username}`}>
+      <Link to={`/profiles/${props.author.username}`}>
         <div className="">
           <img className="rounded-circle float-left mr-3 avatar" src={parseAvatar(props.author.image)} alt="author avatar" />
           <p className="text-muted align-middle">

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -53,7 +53,7 @@ Following:
           <p className="mt-4">
             {bio}
           </p>
-          <button type="button" className="btn button-primary" onClick={editOwnProfile}>Edit Profile</button>
+          <button type="button" className="btn button-primary" onClick={editOwnProfile} hidden={!props.isOwnProfile}>Edit Profile</button>
         </div>
       </div>
     </div>

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -18,6 +18,7 @@ const Routes = () => (
       <Route path="/password-reset" exact strict component={PasswordResetView} />
       <Route path="/password-reset/:token" exact strict component={PasswordResetView} />
       <Route path="/profile" exact strict component={ProfileView} />
+      <Route path="/profiles/:username" exact strict component={ProfileView} />
       <Route path="/profile/edit" exact strict component={UpdateView} />
       <Route path="/article/:slug" exact strict component={ArticleReadView} />
       <Route path="/article/:slug/report" exact strict component={ReportArticleView} />

--- a/src/views/ProfileView.js
+++ b/src/views/ProfileView.js
@@ -12,7 +12,7 @@ export class ProfileView extends React.Component {
   }
 
   componentDidMount() {
-    this.props.getProfiles();
+    this.props.getProfiles(this.props.match.params.username);
   }
 
   render() {
@@ -31,9 +31,12 @@ export class ProfileView extends React.Component {
     if (this.props.loading) {
       return <div className="loadingmsg card">Loading...</div>;
     }
+    const ownUsername = localStorage.getItem('username');
+    const paramUsername = this.props.match.params.username || ownUsername;
+    const isOwnProfile = ownUsername === paramUsername;
     return (
       <div>
-        <Profile profile={this.props.profile} />
+        <Profile profile={this.props.profile} isOwnProfile={isOwnProfile} />
       </div>
     );
   }
@@ -48,8 +51,8 @@ const mapStateToProps = state => ({
 
 
 const mapDispatchToProps = dispatch => ({
-  getProfiles: () => {
-    dispatch(fetchProfile());
+  getProfiles: (username) => {
+    dispatch(fetchProfile(username));
   },
 });
 

--- a/tests/ProfileView.test.js
+++ b/tests/ProfileView.test.js
@@ -8,6 +8,7 @@ describe('profile view', () => {
     const props = {
       getProfiles: jest.fn(),
       loading: 'loading',
+      match: { params: {} },
     }; const wrapper = shallow(<ProfileView {...props} />);
     expect(wrapper).toMatchSnapshot();
   });
@@ -15,12 +16,14 @@ describe('profile view', () => {
     const props = {
       getProfiles: jest.fn(),
       error: 'error',
+      match: { params: {} },
     }; const wrapper = shallow(<ProfileView {...props} />);
     expect(wrapper).toMatchSnapshot();
   });
   it('should render without crashing', () => {
     const props = {
       getProfiles: jest.fn(),
+      match: { params: {} },
     }; const wrapper = shallow(<ProfileView {...props} />);
     expect(wrapper).toMatchSnapshot();
   });


### PR DESCRIPTION
#### What does this PR do?
This PR introduces functionality for authenticated users to visit other users profiles.
#### Description of Task to be completed?
As an authenticated user, I should be able to visit any single profile on authors haven. this will allow me to follow or unfollow that profile.

#### How should this be manually tested?
- Fetch and checkout into this branch with `git fetch origin ft-visit-profile-164241177 && git checkout ft-visit-profile-164241177`
- Install dependencies and start the app with `yarn install && yarn start`
- login to your author's haven account.
- navigate to your profile with `/profile`
- navigate to another users profile with `/profiles/:username`

#### What are the relevant pivotal tracker stories?
[#164241177](https://www.pivotaltracker.com/story/show/164241177)